### PR TITLE
Update extension for compatibility with ET 5.4.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: events, calendar, tickets
 Requires at least: 5.0
 Tested up to: 5.8.1
 Requires PHP: 7.0
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPL version 2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -32,7 +32,12 @@ We're always interested in your feedback and our [premium forums](https://theeve
 
 == Changelog ==
 
-= [1.0.2] TBD =
+= [1.0.3] 2022-05-19 =
+
+* Move settings to new Ticket Settings admin menu section.
+* Add support for Tickets Commerce. 
+
+= [1.0.2] 2021-10-21 =
 
 * Fixed plugin name typo
 

--- a/src/Main.php
+++ b/src/Main.php
@@ -18,18 +18,15 @@ namespace Tribe__Extension__Ticket_Email_Settings;
  * @since 1.0.0
  */
 class Main {
-
     /**
      * Extension initialization and hooks.
      */
     public function init() {
-
         // Load required files
         require_once( 'Ticket_Emails__Abstract.php' );
 
         // Load and boot our modules
         array_map( function( $module ) {
-
             // Load the file
             require_once( $module . ".php" );
 
@@ -46,6 +43,7 @@ class Main {
             'Content',
             'Ticket_Emails__RSVP',
             'Ticket_Emails__TPP',
+            'Ticket_Emails__TC',
             'Ticket_Emails__Woo',
             'Ticket_Emails__EDD'
         ]);

--- a/src/Settings_Tab.php
+++ b/src/Settings_Tab.php
@@ -25,7 +25,6 @@ class Settings_Tab {
      * Add action to create settings tab.
      */
     public function init() {
-
         // Create the settings panel
         add_action( 'tribe_settings_do_tabs', [ $this, 'add_settings_tabs' ] );
     }
@@ -37,7 +36,16 @@ class Settings_Tab {
      *
      * @return void
      */
-    public function add_settings_tabs() {
+    public function add_settings_tabs( $admin_page ) {
+        if ( ! method_exists( tribe( 'tickets.main' ), 'settings') ) {
+            return;
+        }
+
+        $tickets_settings_page_id = tribe( 'tickets.main' )->settings()::$settings_page_id;
+
+        if ( ! empty( $admin_page ) && $tickets_settings_page_id !== $admin_page ) {
+            return;
+        }
 
         // Create the settings tab.
         $settings_tab = new Tribe__Settings_Tab( 'ticket-emails', __( 'Ticket Emails', 'tribe-ext-ticket-email-settings' ), $this->get_field_data() );
@@ -51,7 +59,6 @@ class Settings_Tab {
      * @return array
      */
     private function get_field_data() {
-
         $field_data = [
             'priority' => 25,
             'fields'   => [

--- a/src/Ticket_Emails__TC.php
+++ b/src/Ticket_Emails__TC.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Ticket Emails TPP
+ *
+ * This file contains the class for Tribe Commerce email actions.
+ *
+ * @package   Tribe Extension: Ticket Email Settings
+ * @copyright 2020 Modern Tribe
+ * @license   https://www.gnu.org/licenses/gpl-2.0.html GPL-2.0-or-later
+ * @link      https://github.com/mt-support/tribe-ext-ticket-email-settings
+ */
+
+namespace Tribe__Extension__Ticket_Email_Settings;
+
+use TEC\Tickets\Commerce\Settings;
+use function tribe_get_option;
+
+/**
+ * Class Ticket_Emails_TPP
+ *
+ * @since 1.0.0
+ */
+class Ticket_Emails__TC extends Ticket_Emails__Abstract {
+    /**
+     * Add filter for the email subject.
+     *
+     * @since 1.0.0
+     *
+     * @return void
+     */
+    public function add_subject_actions() {
+        add_filter( 'tribe_tickets_ticket_email_subject', [ $this, 'get_subject' ] );
+    }
+
+    /**
+     * Add filter for the email headers.
+     *
+     * @since 1.0.0
+     *
+     * @return void
+     */
+    public function add_header_actions() {
+        add_filter( 'tribe_tickets_ticket_email_headers', [ $this, 'get_headers' ], 100, 2 );
+    }
+
+    /**
+     * Generate the email headers for Tribe Commerce.
+     *
+     * @since 1.0.0
+     *
+     * @param string $headers - the default headers
+     * @param int $post_id - the post id of the event.
+     * @return string
+     */
+    public function get_headers( $headers, $post_id ) {
+        // String to store the email headers. 
+        $headers = "Content-Type: text/html" . "\r\n";
+
+        // Set the default from name. 
+        $default_from_name = tribe_get_option( Settings::$option_confirmation_email_sender_name, false );
+
+        // Set the default from email. 
+        $default_from_email = tribe_get_option( Settings::$option_confirmation_email_sender_email, false );
+
+        // Set the from name with our custom value.
+        $from_name = $this->get_option( 'ticketEmailsFromName', $default_from_name );
+
+        // Set the from email with our custom value.
+        $from_email = $this->get_option( 'ticketEmailsFromEmail', $default_from_email );
+
+        // Add from.
+        $headers .= sprintf( "From: %s <%s>", $this->clean_text( $from_name ), $from_email ) . "\r\n";
+
+        // Add reply to.
+        $headers .= sprintf( "Reply-To: %s", $from_email ) . "\r\n";
+
+        // Get a string of emails to bcc.
+        if( $bcc = $this->get_bcc_emails( $post_id ) ) {
+            $headers .= sprintf( "Bcc: %s", $bcc ) . "\r\n";
+        }
+
+        // Get a string of emails to cc.
+        if( $cc = $this->get_option( 'ticketEmailsCC' ) ) {
+            $headers .= sprintf( "Cc: %s", $cc ) . "\r\n";
+        }
+
+        return $headers;
+    }
+}

--- a/tribe-ext-ticket-email-settings.php
+++ b/tribe-ext-ticket-email-settings.php
@@ -36,7 +36,7 @@ class Tribe__Extension__Ticket_Email_Settings extends Tribe__Extension {
      * Setup the Extension's properties.
      */
     public function construct() {
-        $this->add_required_plugin( 'Tribe__Tickets__Main' );
+        $this->add_required_plugin( 'Tribe__Tickets__Main', '5.4.0' );
     }
 
     /**

--- a/tribe-ext-ticket-email-settings.php
+++ b/tribe-ext-ticket-email-settings.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/tribe-ext-ticket-email-settings
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-ticket-email-settings
  * Description:       An extension that adds a tab for ticket email settings in the event settings.
- * Version:           1.0.2
+ * Version:           1.0.3
  * Extension Class:   Tribe__Extension__Ticket_Email_Settings
  * Author:            The Events Calendar
  * Author URI:        http://evnt.is/1971
@@ -30,7 +30,7 @@ if( ! class_exists( 'Tribe__Extension' ) ) {
  */
 class Tribe__Extension__Ticket_Email_Settings extends Tribe__Extension {
 
-    private static $version = "1.0.1";
+    private static $version = "1.0.3";
 
     /**
      * Setup the Extension's properties.


### PR DESCRIPTION
The work in this PR makes the ticket email extension compatible with Event Tickets v 5.4.0, which moves Event Tickets settings to a new admin menu location.

This also adds support for Tickets Commerce. 