### PR TITLE
Fix broken email headers

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,10 @@ We're always interested in your feedback and our [premium forums](https://theeve
 
 == Changelog ==
 
+= [1.0.4] 2022-10-26 =
+
+* Fix email headers from being overridden by TC callback.
+
 = [1.0.3] 2022-05-19 =
 
 * Move settings to new Ticket Settings admin menu section.

--- a/src/Ticket_Emails__Abstract.php
+++ b/src/Ticket_Emails__Abstract.php
@@ -93,7 +93,7 @@ class Ticket_Emails__Abstract {
         }
 
         // If there's any emails in the array, convert to comma separated string
-        return ( ! empty( $bcc ) ) ? implode( ",", $bcc ) : false;
+        return ( ! empty( $bcc ) ) ? implode( ",", $bcc ) : '';
     }
 
     /**
@@ -125,15 +125,11 @@ class Ticket_Emails__Abstract {
 
                 // Loop through the organizers
                 foreach( $organizers as $organizer_id ) {
-
-                    // Get the organizer name
-                    $organizer_name = $this->clean_text( tribe_get_organizer( $organizer_id ) );
-
                     // Get the organizer email address
                     $organizer_email = $this->clean_text( tribe_get_organizer_email( $organizer_id ) );
 
                     // Add the organizer email info to our emails array
-                    $emails[] = $organizer_name . "<$organizer_email>";
+                    $emails[] = $organizer_email;
                 }
             }
         }

--- a/src/Ticket_Emails__TC.php
+++ b/src/Ticket_Emails__TC.php
@@ -40,7 +40,7 @@ class Ticket_Emails__TC extends Ticket_Emails__Abstract {
      * @return void
      */
     public function add_header_actions() {
-        add_filter( 'tribe_tickets_ticket_email_headers', [ $this, 'get_headers' ], 100, 2 );
+        add_filter( 'tribe_tickets_ticket_email_headers', [ $this, 'get_headers' ], 100, 6 );
     }
 
     /**
@@ -52,7 +52,11 @@ class Ticket_Emails__TC extends Ticket_Emails__Abstract {
      * @param int $post_id - the post id of the event.
      * @return string
      */
-    public function get_headers( $headers, $post_id ) {
+    public function get_headers( $headers, $post_id, $order_id, $tickets, $provider, $args ) {
+        if ( empty( $post_id ) || 'tpp' !== $provider ) {
+            return $headers;
+        }
+
         // String to store the email headers. 
         $headers = "Content-Type: text/html" . "\r\n";
 

--- a/tribe-ext-ticket-email-settings.php
+++ b/tribe-ext-ticket-email-settings.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/tribe-ext-ticket-email-settings
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-ticket-email-settings
  * Description:       An extension that adds a tab for ticket email settings in the event settings.
- * Version:           1.0.3
+ * Version:           1.0.4
  * Extension Class:   Tribe__Extension__Ticket_Email_Settings
  * Author:            The Events Calendar
  * Author URI:        http://evnt.is/1971
@@ -30,7 +30,7 @@ if( ! class_exists( 'Tribe__Extension' ) ) {
  */
 class Tribe__Extension__Ticket_Email_Settings extends Tribe__Extension {
 
-    private static $version = "1.0.3";
+    private static $version = "1.0.4";
 
     /**
      * Setup the Extension's properties.


### PR DESCRIPTION
The class we added for Tickets Commerce had a callback for the ticket email headers that was overriding other providers. 

This fixes that by adding a check for the provider in the TC class. 